### PR TITLE
ESPHome 2025.2 compatibility

### DIFF
--- a/how_to_flash.md
+++ b/how_to_flash.md
@@ -53,8 +53,6 @@ remote_receiver:
     value: 26us
   idle: 1500us
   buffer_size: 15kB
-  memory_blocks: 5
-  clock_divider: 160
   on_abbwelcome:
     then:
       - lambda: 'id(doorbell_intercom).publish_state(x.to_string().c_str());'


### PR DESCRIPTION
As discussed in issue #14 
Removing `memory_blocks: 5` and `clock_divider: 160` to ensure ESPHome 2025.2 compatibility.