### PR TITLE
Use `substitutions` in code examples

### DIFF
--- a/how_to_customize.md
+++ b/how_to_customize.md
@@ -22,12 +22,12 @@ After uploading the [basic configuration](https://github.com/Mat931/esp32-doorbe
       - if:
           condition:
             or:
-              # Type 01, Outdoor Station (0x2001) > Indoor Station #12 (0x100c)
-              - lambda: 'return (x.get_message_type() == 0x01) && (x.get_source_address() == 0x2001) && (x.get_destination_address() == 0x100c);'
-              # Type 81, Indoor Station #12 (0x100c) > Outdoor Station (0x2001)
-              - lambda: 'return (x.get_message_type() == 0x81) && (x.get_source_address() == 0x100c) && (x.get_destination_address() == 0x2001);'
-              # Type 0a, Outdoor Station (0x2001) > Gateway (0x3001), Data contains indoor station address (0x10, 0x0c)
-              - lambda: 'std::vector<uint8_t> d = {0x01, 0x10, 0x0c}; return (x.get_message_type() == 0x0A) && (x.get_source_address() == 0x2001) && (x.get_destination_address() == 0x3001) && (x.get_data() == d);'
+              # Type 01, Outdoor Station (0x2001) > Indoor Station
+              - lambda: 'return (x.get_message_type() == 0x01) && (x.get_source_address() == ${outdoor_station_address}) && (x.get_destination_address() == ${indoor_station_address});'
+              # Type 81, Indoor Station > Outdoor Station (0x2001)
+              - lambda: 'return (x.get_message_type() == 0x81) && (x.get_source_address() == ${indoor_station_address}) && (x.get_destination_address() == ${outdoor_station_address});'
+              # Type 0a, Outdoor Station > Gateway (0x3001), Data contains indoor station address (0x10, 0x0c)
+              - lambda: 'std::vector<uint8_t> d = {0x01, 0x10, 0x0c}; return (x.get_message_type() == 0x0A) && (x.get_source_address() == ${outdoor_station_address}) && (x.get_destination_address() == 0x3001) && (x.get_data() == d);'
           then:
           - binary_sensor.template.publish:
               id: doorbell_outdoor
@@ -43,10 +43,10 @@ After uploading the [basic configuration](https://github.com/Mat931/esp32-doorbe
       - if:
           condition:
             or:
-              # Type 11, Source: Indoor Station (0x100C)
-              - lambda: 'return (x.get_message_type() == 0x11) && (x.get_source_address() == 0x100c);'
-              # Type 91, Destination: Indoor Station (0x100C)
-              - lambda: 'return (x.get_message_type() == 0x91) && (x.get_destination_address() == 0x100c);'
+              # Type 11, Source: Indoor Station
+              - lambda: 'return (x.get_message_type() == 0x11) && (x.get_source_address() == ${indoor_station_address});'
+              # Type 91, Destination: Indoor Station
+              - lambda: 'return (x.get_message_type() == 0x91) && (x.get_destination_address() == ${indoor_station_address});'
           then:
           - binary_sensor.template.publish:
               id: doorbell_indoor
@@ -65,9 +65,9 @@ After uploading the [basic configuration](https://github.com/Mat931/esp32-doorbe
 ```yaml
 on_...:
   - remote_transmitter.transmit_abbwelcome:
-      source_address: 0x100c # your indoor station address
-      destination_address: 0x4001 # door address
-      three_byte_address: false # address length of your system
+      source_address: ${indoor_station_address}
+      destination_address: ${outdoor_station_address}
+      three_byte_address:  ${three_byte_address_bool}
       message_type: 0x0d # unlock door
       data: [0xab, 0xcd, 0xef] # message data
 ```
@@ -79,7 +79,7 @@ on_...:
           condition:
             and:
               - lambda: 'return (x.get_message_type() == 0x8d);' # Door opener response
-              - lambda: 'return (x.get_source_address() == 0x4001);' # Door address
+              - lambda: 'return (x.get_source_address() == ${outdoor_door_address});'
           then:
           - lock.template.publish:
               id: main_door

--- a/how_to_flash.md
+++ b/how_to_flash.md
@@ -2,6 +2,15 @@ The ESP32 on this board must be programmed with a firmware like [ESPHome](https:
 
 ## ESPHome Example Configuration
 ```yaml
+substitutions:
+  device_name: abb-welcome-demo
+  friendly_name: "ABB Welcome Demo"
+  # check https://github.com/Mat931/esp32-doorbell-bus-interface/blob/main/how_to_customize.md to get the correct values for your system
+  indoor_station_address: 0x1001  # your indoor station address
+  outdoor_station_address: 0x2001 # outdoor station address
+  outdoor_door_address: 0x4001    # outdoor door address
+  three_byte_address_bool: false  # address length of your system
+
 esp32:
   board: esp32dev
   framework:
@@ -10,8 +19,8 @@ esp32:
       CONFIG_FREERTOS_UNICORE: y # Only required if you have a single core ESP32
 
 esphome:
-  name: abb-welcome-demo
-  friendly_name: "ABB Welcome Demo"
+  name: ${device_name}
+  friendly_name: ${friendly_name}
   on_boot:
     - lock.template.publish:
         id: front_door
@@ -64,7 +73,7 @@ remote_receiver:
           condition:
             and:
               - lambda: "return (x.get_message_type() == 0x8d);" # unlock door response
-              - lambda: "return (x.get_source_address() == 0x4001);" # door address
+              - lambda: "return (x.get_source_address() == ${outdoor_door_address});"
           then:
             - lock.template.publish:
                 id: front_door
@@ -77,7 +86,7 @@ remote_receiver:
           condition:
             and:
               - lambda: "return (x.get_message_type() == 0x11);" # doorbell indoor
-              - lambda: "return (x.get_source_address() == 0x1001);" # your indoor station address
+              - lambda: "return (x.get_source_address() == ${indoor_station_address});"
           then:
             - binary_sensor.template.publish:
                 id: doorbell_indoor
@@ -89,8 +98,8 @@ remote_receiver:
           condition:
             and:
               - lambda: "return (x.get_message_type() == 0x01);" # doorbell outdoor
-              - lambda: "return (x.get_source_address() == 0x2001);" # outdoor station address
-              - lambda: "return (x.get_destination_address() == 0x1001);" # your indoor station address
+              - lambda: "return (x.get_source_address() == ${outdoor_station_address});"
+              - lambda: "return (x.get_destination_address() == ${indoor_station_address});"
           then:
             - binary_sensor.template.publish:
                 id: doorbell_outdoor
@@ -141,9 +150,9 @@ lock:
     unlock_action:
       - then:
           - remote_transmitter.transmit_abbwelcome:
-              source_address: 0x1001 # your indoor station address
-              destination_address: 0x4001 # door address
-              three_byte_address: false # address length of your system
+              source_address: ${indoor_station_address}
+              destination_address: ${outdoor_door_address}
+              three_byte_address: ${three_byte_address_bool}
               message_type: 0x0d # unlock door
               data: [0xab, 0xcd, 0xef] # door opener secret code, see receiver dump
 
@@ -156,9 +165,9 @@ button:
     name: "Stop Doorbell"
     on_press:
       - remote_transmitter.transmit_abbwelcome:
-          source_address: 0x1001 # your indoor station address
-          destination_address: 0x2001 # outdoor station address
-          three_byte_address: false # address length of your system
+          source_address: ${indoor_station_address}
+          destination_address: ${outdoor_station_address}
+          three_byte_address: ${three_byte_address_bool}
           message_type: 0x02 # end call (stops your doorbell ringtone)
           data: [0x00]
 


### PR DESCRIPTION
Define and use `substitutions` in code examples to facilitate adapting the example to the user's values.
Although it is commonly used in my implementations, I have not validated this particular code (as I do not yet have the device).

Refs:
* https://esphome.io/components/substitutions/